### PR TITLE
Configure postgres with environment variables

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -21,6 +21,7 @@ common_param_env_vars_enabled: true
 param_container_name: "{{ project_name }}"
 param_usage_include_env: true
 param_env_vars:
+  - { env_var: "DB_DIALECT", env_value: "mysql", desc: "Type of database, default is mysql (mysql, postgres)" }
   - { env_var: "DB_HOST", env_value: "<hostname or ip>", desc: "Host address of mysql database" }
   - { env_var: "DB_PORT", env_value: "3306", desc: "Port to access mysql database default is 3306" }
   - { env_var: "DB_USER", env_value: "codimd", desc: "Database user" }
@@ -60,6 +61,7 @@ custom_compose: |
       volumes:
         - <path to config>:/config
       environment:
+        - DB_DIALECT=mysql
         - DB_HOST=mariadb
         - DB_USER=codimd
         - DB_PASS=<secret password>

--- a/root/etc/services.d/codimd/run
+++ b/root/etc/services.d/codimd/run
@@ -2,7 +2,7 @@
 
 # if user is using our env variables set the DB_URL
 [[ -n ${DB_HOST+x} ]] && \
-	export CMD_DB_URL="mysql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+	export CMD_DB_URL="${DB_DIALECT:-mysql}://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
 
 # set env var for sqlite if db url unset
 [[ -z ${CMD_DB_URL+x} ]] && \


### PR DESCRIPTION
## Description:
This allows users to configure mysql and postgres with environment variables.

## Benefits of this PR and context:
Leaves the choice of the DB-Backends to the user

## How Has This Been Tested?
I have tested the image with postgres only with environment variables.

## Source / References:
References #8 
